### PR TITLE
Bugfix: make sure home nav css class override function returns a value in all cases

### DIFF
--- a/includes/nav-functions.php
+++ b/includes/nav-functions.php
@@ -66,8 +66,9 @@ add_filter( 'wp_nav_menu_objects', __NAMESPACE__ . '\home_icon_nav_menu_objects'
  */
 function home_icon_nav_menu_css_class( $classes, $item, $args, $depth ) {
 	if ( $args->theme_location === 'home-icon-menu' ) {
-		return array( 'quicklinks-item' );
+		$classes = array( 'quicklinks-item' );
 	}
+	return $classes;
 }
 
 add_filter( 'nav_menu_css_class', __NAMESPACE__ . '\home_icon_nav_menu_css_class', 10, 4 );


### PR DESCRIPTION
<!---
Thank you for contributing to Coronavirus-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Coronavirus-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
See title

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When using the menu assigned to the Home Icon Menu location in another place (e.g. a widget), a warning gets thrown by the main WP Nav Walker class due to `home_icon_nav_menu_css_class()` not properly returning a `$classes` array in all cases.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
