### PR TITLE
Fixed issues with h1 elem on homepage when primary site nav is disabled

### DIFF
--- a/template-parts/header_content-title_subtitle.php
+++ b/template-parts/header_content-title_subtitle.php
@@ -5,7 +5,7 @@ $obj              = ucfwp_get_queried_object();
 $title            = ucfwp_get_header_title( $obj );
 $subtitle         = ucfwp_get_header_subtitle( $obj );
 $h1               = ucfwp_get_header_h1_option( $obj );
-$h1_elem          = ( is_home() || is_front_page() ) ? 'h2' : 'h1'; // name is misleading but we need to override this elem on the homepage
+$h1_elem          = ucfwp_get_header_h1_elem( $obj );
 $title_elem       = ( $h1 === 'title' ) ? $h1_elem : 'span';
 $subtitle_elem    = ( $h1 === 'subtitle' ) ? $h1_elem : 'p';
 $title_classes    = 'cv-header-title mb-1 mb-sm-2';


### PR DESCRIPTION
<!---
Thank you for contributing to Coronavirus-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Coronavirus-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Fixes the display of the page title on the homepage when the primary site nav is disabled.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Without this update, the page title on the homepage was incorrectly rendering as a `h2`.

Dependent on https://github.com/UCF/UCF-WordPress-Theme/pull/83.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
