### PR TITLE
Remove site nav

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -466,25 +466,6 @@
                 "endpoint": 0
             },
             {
-                "key": "field_5a0dead0cd525",
-                "label": "Exclude Primary Site Navigation",
-                "name": "page_header_exclude_nav",
-                "type": "true_false",
-                "instructions": "Controls whether or not the primary site navigation should be displayed at the top of the page.",
-                "required": 0,
-                "conditional_logic": 0,
-                "wrapper": {
-                    "width": "",
-                    "class": "",
-                    "id": ""
-                },
-                "message": "Exclude site navigation",
-                "default_value": 0,
-                "ui": 0,
-                "ui_on_text": "",
-                "ui_off_text": ""
-            },
-            {
                 "key": "field_5a56501afb51e",
                 "label": "Include Subnavigation",
                 "name": "page_header_include_subnav",

--- a/includes/config.php
+++ b/includes/config.php
@@ -23,6 +23,9 @@ function init() {
 	// Custom menu location for this theme's homepage icon grid
 	register_nav_menu( 'home-icon-menu', __( 'Home Icon Menu' ) );
 
+	// Remove unused header menu registered in UCF WP Theme
+	unregister_nav_menu( 'header-menu' );
+
 	// Remove unused image sizes registered in UCF WP Theme
 	remove_image_size( 'bg-img' );
 	remove_image_size( 'bg-img-sm' );

--- a/includes/nav-functions.php
+++ b/includes/nav-functions.php
@@ -6,6 +6,20 @@ namespace Coronavirus\Theme\Includes\Nav_Functions;
 
 
 /**
+ * Replaces the UCF WP Theme's nav markup with an empty string
+ * (effectively disabling the site nav in the header).
+ *
+ * Shouldn't really be in use anywhere since this theme overrides
+ * the `header-media` template part and enforces it everywhere,
+ * but added for good measure anyway.
+ *
+ * @since 1.0.0
+ * @author Jo Dickson
+ */
+add_filter( 'ucfwp_get_nav_markup', '__return_empty_string' );
+
+
+/**
  * Modifies standard wp_nav_menu() output to display
  * Home Icon Menu icons.
  *

--- a/template-parts/header-media.php
+++ b/template-parts/header-media.php
@@ -16,7 +16,7 @@ $header_content_type = ucfwp_get_header_content_type( $obj );
 				echo ucfwp_get_media_background_video( $videos, $video_loop );
 			}
 			if ( $images ) {
-				$bg_image_srcs = ucfwp_get_header_media_picture_srcs( $header_height, $images );
+				$bg_image_srcs = ucfwp_get_header_media_picture_srcs( null, $images );
 				echo ucfwp_get_media_background_picture( $bg_image_srcs );
 			}
 			?>

--- a/template-parts/header-media.php
+++ b/template-parts/header-media.php
@@ -1,0 +1,43 @@
+<?php
+$obj        = ucfwp_get_queried_object();
+$videos     = ucfwp_get_header_videos( $obj );
+$images     = ucfwp_get_header_images( $obj );
+$video_loop = get_field( 'page_header_video_loop', $obj );
+$header_content_type = ucfwp_get_header_content_type( $obj );
+?>
+
+<div class="header-media mb-0 d-flex flex-column">
+	<div class="header-media-background-wrap">
+		<div class="header-media-background media-background-container">
+			<?php
+			// Display the media background (video + picture)
+
+			if ( $videos ) {
+				echo ucfwp_get_media_background_video( $videos, $video_loop );
+			}
+			if ( $images ) {
+				$bg_image_srcs = ucfwp_get_header_media_picture_srcs( $header_height, $images );
+				echo ucfwp_get_media_background_picture( $bg_image_srcs );
+			}
+			?>
+		</div>
+	</div>
+
+	<?php
+	// Display the inner header contents
+	?>
+	<div class="header-content">
+		<div class="header-content-flexfix">
+			<?php echo ucfwp_get_header_content_markup(); ?>
+		</div>
+	</div>
+
+	<?php
+	// Print a spacer div for headers with background videos (to make
+	// control buttons accessible), and for headers showing a standard
+	// title/subtitle to push them up a bit
+	if ( $videos || $header_content_type === 'title_subtitle' ):
+	?>
+	<div class="header-media-controlfix"></div>
+	<?php endif; ?>
+</div>


### PR DESCRIPTION
<!---
Thank you for contributing to Coronavirus-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Coronavirus-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Removes the primary site nav everywhere in the theme.  Adds a template part override for `header-media.php` to completely omit the site nav (as well as header heights, which are not in use in this theme).

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
v1.0.0 requirements.  Resolves #18 

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.  

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
