### PR TITLE
Bugfix for post excerpt replacement logic

### DIFF
--- a/includes/post-functions.php
+++ b/includes/post-functions.php
@@ -7,7 +7,7 @@ namespace Coronavirus\Theme\Includes\Post_Functions;
 
 function update_excerpt( $excerpt, $post ) {
 	if ( $post && $post->post_type === 'post' ) {
-		$deck = get_field( 'post_deck' );
+		$deck = get_field( 'post_deck', $post );
 
 		$excerpt = ! empty( $deck ) ? $deck : $excerpt;
 	}


### PR DESCRIPTION
<!---
Thank you for contributing to Coronavirus-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Coronavirus-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Fixes the custom excerpt filter in this theme for posts to replace excerpts with the post's deck, if available.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We weren't passing in the relevant `$post` object to `get_field()` when retrieving the post's deck, so the excerpt override wasn't working.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
